### PR TITLE
Added referencing counting to array class

### DIFF
--- a/quickcluster/include/quickcluster/kmeans/kmeans.h
+++ b/quickcluster/include/quickcluster/kmeans/kmeans.h
@@ -29,7 +29,7 @@ private:
     size_t closest_centroid_index(const Array<float> &feature, const Array<float> &centroids) const;
 
     // From a group of features, set the mean of the centroid at index
-    bool set_centroid_mean(const vector<reference_wrapper<Array<float>>> &features, Array<float> &centroids, size_t index) const;
+    bool set_centroid_mean(const vector<Array<float>> &features, Array<float> &centroids, size_t index) const;
 
 public:
 

--- a/quickcluster/include/quickcluster/linearalgebra/array.h
+++ b/quickcluster/include/quickcluster/linearalgebra/array.h
@@ -21,6 +21,8 @@ private:
     // Used to keep track if the underlying memory is managed by this class or outside
     bool _self_managed;
 
+    int *_rc;
+
 public:
 
     // Equates to an empty array
@@ -34,7 +36,7 @@ public:
     
     // Takes a single dimension buffer and resizes it, the length of the buffer must be equal to Rows x Cols.
     // If copy is set to true, the buffer is copied and the class handles its own memory
-    Array(T* buffer, size_t Rows, size_t Cols, bool copy = false);
+    Array(T* buffer, size_t Rows, size_t Cols, bool copy = false, int *reference_count = nullptr);
 
     // Create an array of random values
     static Array<T> random(size_t N, T max = 1);
@@ -97,6 +99,8 @@ public:
 
     // Compares this array to another
     bool operator==(const Array<T> &other) const;
+
+    int __reference_count() const;
 };
 
 #endif

--- a/quickcluster/src/quickcluster/kmeans/kmeans.cc
+++ b/quickcluster/src/quickcluster/kmeans/kmeans.cc
@@ -29,7 +29,7 @@ void KMeans::fit(const Array<float> &data) {
     auto centroids = this->create_centroids(data);
 
     // We will group the centroids here
-    vector<reference_wrapper<Array<float>>> grouped_features[this->_k];
+    vector<Array<float>> grouped_features[this->_k];
 
     // Number of rows
     size_t rows = data.rows();
@@ -111,14 +111,14 @@ size_t KMeans::closest_centroid_index(const Array<float> &feature, const Array<f
     return closest_index;
 }
 
-bool KMeans::set_centroid_mean(const vector<reference_wrapper<Array<float>>> &features, Array<float> &centroids, size_t index) const {
+bool KMeans::set_centroid_mean(const vector<Array<float>> &features, Array<float> &centroids, size_t index) const {
 
     if (features.empty()) {
         return false;
     }
 
     size_t rows = features.size();
-    size_t cols = features[0].get().size();
+    size_t cols = features[0].size();
 
     bool converged = true;
     
@@ -127,7 +127,7 @@ bool KMeans::set_centroid_mean(const vector<reference_wrapper<Array<float>>> &fe
         float total = 0.0;
 
         for (size_t i = 0; i < rows; i++) {
-            total += features[i].get()[col];
+            total += features[i][col];
         }
 
         size_t offset = index * cols;


### PR DESCRIPTION
Added a reference counting mechanic to the array class to support a custom copy constructor to prevent the unnecessary copying of data.